### PR TITLE
Change record prefix from ISEG:$CONTROLLER_SN to $P$R.

### DIFF
--- a/devIsegHalApp/Db/iseg_epics.db
+++ b/devIsegHalApp/Db/iseg_epics.db
@@ -7,7 +7,6 @@
 # ###                                                             ### #
 # ### Ref 1.02; 2017-02-28                                        ### #
 # ###                                                             ### #
-# ### macros: CONTROLLER_SN    serial number of crate controller  ### #
 # ###         CAN_LINE    CAN line ID                             ### #
 # ###         CRATE_ID    crate address                           ### #
 # ###         MODULE_ID   module address                          ### #
@@ -18,41 +17,41 @@
 # ### CAN_System item values ##
 ###############################
 
-record( stringin, "ISEG:${CONTROLLER_SN}:Status" ) {
+record( stringin, "${P}${R}Status" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@Status $(port)" )	
-  field( FLNK, "ISEG:${CONTROLLER_SN}:BitRate" )
+  field( FLNK, "${P}${R}BitRate" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:BitRate" ) {
+record( longin, "${P}${R}BitRate" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@BitRate $(port)" )
   field( TSE,  "-2" )
 }	
 
-record( longin, "ISEG:${CONTROLLER_SN}:ModuleNumber" ) {
+record( longin, "${P}${R}ModuleNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@ModuleNumber $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:CrateNumber" )
+  field( FLNK, "${P}${R}CrateNumber" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:CrateNumber" ) {
+record( longin, "${P}${R}CrateNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@CrateNumber $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:CrateList" )
+  field( FLNK, "${P}${R}CrateList" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:CrateList" ) {
+record( stringin, "${P}${R}CrateList" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@CrateList $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:CycleCounter" )
+  field( FLNK, "${P}${R}CycleCounter" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:CycleCounter" ) {
+record( longin, "${P}${R}CycleCounter" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@CycleCounter $(port)" )
   field( TSE,  "-2" )
@@ -62,41 +61,41 @@ record( longin, "ISEG:${CONTROLLER_SN}:CycleCounter" ) {
 # ### CAN_Line item values ##
 #############################
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:Status" ) {
+record( stringin, "${P}${R}${CAN_LINE}:Status" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.Status $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:BitRate" )
+  field( FLNK, "${P}${R}${CAN_LINE}:BitRate" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:BitRate" ) {
+record( longin, "${P}${R}${CAN_LINE}:BitRate" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.BitRate $(port)" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:ModuleNumber" ) {
+record( longin, "${P}${R}${CAN_LINE}:ModuleNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.ModuleNumber $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:ModuleList" )
+  field( FLNK, "${P}${R}${CAN_LINE}:ModuleList" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:ModuleList" ) {
+record( stringin, "${P}${R}${CAN_LINE}:ModuleList" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.ModuleList $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:CrateNumber" )
+  field( FLNK, "${P}${R}${CAN_LINE}:CrateNumber" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:CrateNumber" ) {
+record( longin, "${P}${R}${CAN_LINE}:CrateNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.CrateNumber $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:CrateList" )
+  field( FLNK, "${P}${R}${CAN_LINE}:CrateList" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:CrateList" ) {
+record( stringin, "${P}${R}${CAN_LINE}:CrateList" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.CrateList $(port)" )
   field( TSE,  "-2" )
@@ -106,7 +105,7 @@ record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:CrateList" ) {
 # ### Crate item values ### #
 #############################
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusLow" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusLow" ) {
   field( DESC, "Lower 16 bit of module status register" )
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.Status $(port)" )
@@ -115,7 +114,7 @@ record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusLow" )
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusHigh" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusHigh" ) {
   field( DESC, "Upper 16 bit of module status register" )
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.Status $(port)" )
@@ -127,13 +126,13 @@ record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusHigh" 
 # Alternative way to read out the status:
 # In this case only the calc record needs to be triggered
 
-#record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusRead__" ) {
+#record( longin, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusRead__" ) {
 #  field( DTYP, "isegHAL" )
 #  field( INP,  "@${CAN_LINE}.${DEVICE_ID}.Status $(port)" )
 #}
-#record( calc, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusSplit__" ) {
+#record( calc, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusSplit__" ) {
 #  ## PP = Passive Process: Force the other record to process before sending the value
-#  field( INPA, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusRead PP" )
+#  field( INPA, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusRead PP" )
 #
 #  field( INPB, "0x0000ffff" )
 #  field( INPC, "0xffff0000" )
@@ -142,16 +141,16 @@ record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusHigh" 
 #  ## then set field VAL to ( field A bitwise AND field C ) right shifted by 16 bit
 #  field( CALC, "d:=(A&B); (A&C)>>16" )
 #}
-#record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusLow" ) {
+#record( mbbiDirect, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusLow" ) {
 #  field( DTYP, "Soft Channel" )
-#  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusSplit__.D CP" )
+#  field( INP,  "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusSplit__.D CP" )
 #}
-#record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusHigh" ) {
+#record( mbbiDirect, "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusHigh" ) {
 #  field( DTYP, "Soft Channel" )
-#  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:StatusSplit__.VAL CP" )
+#  field( INP,  "${P}${R}${CAN_LINE}:${DEVICE_ID}:StatusSplit__.VAL CP" )
 #}
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:EventStatusLow" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${DEVICE_ID}:EventStatusLow" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.EventStatus $(port)" )
   field( NOBT, "16" )
@@ -159,25 +158,25 @@ record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:EventStatusL
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:EventStatusHigh" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${DEVICE_ID}:EventStatusHigh" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.EventStatus $(port)" )
   field( NOBT, "16" )
   field( SHFT, "16" )
   field( TSE,  "-2" )
 }
-record( longout, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:EventMask" ) {
+record( longout, "${P}${R}${CAN_LINE}:${DEVICE_ID}:EventMask" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${DEVICE_ID}.EventMask $(port)" )
   field( TSE,  "-2" )
 }
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:FanSpeed" ) {
+record( ai, "${P}${R}${CAN_LINE}:${DEVICE_ID}:FanSpeed" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.FanSpeed $(port)" )
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:Control:doClear" ) {
+record( bo, "${P}${R}${CAN_LINE}:${DEVICE_ID}:Control:doClear" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${DEVICE_ID}.Control:0 $(port)" )
   field( ZNAM, "" )
@@ -186,13 +185,13 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:Control:doClear" ) {
 }
 
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:SerialNumber" ) {
+record( longin, "${P}${R}${CAN_LINE}:${DEVICE_ID}:SerialNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.SerialNumber $(port)" )
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:PowerOn" ) {
+record( bo, "${P}${R}${CAN_LINE}:${DEVICE_ID}:PowerOn" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${DEVICE_ID}.PowerOn $(port)" )
   field( TSE,  "-2" )
@@ -200,21 +199,21 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:PowerOn" ) {
   field( ONAM, "On" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:FirmwareRelease" ) {
+record( stringin, "${P}${R}${CAN_LINE}:${DEVICE_ID}:FirmwareRelease" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.FirmwareRelease $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:FirmwareName" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${DEVICE_ID}:FirmwareName" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:FirmwareName" ) {
+record( stringin, "${P}${R}${CAN_LINE}:${DEVICE_ID}:FirmwareName" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.FirmwareName $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:Article" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${DEVICE_ID}:Article" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:Article" ) {
+record( stringin, "${P}${R}${CAN_LINE}:${DEVICE_ID}:Article" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${DEVICE_ID}.Article $(port)" )
   field( TSE,  "-2" )
@@ -225,54 +224,54 @@ record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:Article" ) {
 # ### Module item values ### #
 ##############################
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${MODULE_ID}:Status" ) {
   field( DESC, "Lower 16 bit of module status register" )
   field( DTYP, "isegHAL" )
   field( DISV, "0" )  ## Disable Value (if value linked by SDIS == DISV record is disabled)
-  field( SDIS, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:PowerOn.VAL NPP MS" )
+  field( SDIS, "${P}${R}${CAN_LINE}:${DEVICE_ID}:PowerOn.VAL NPP MS" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.Status $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:StatusHigh" ) ## Build read out chains
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:StatusHigh" ) ## Build read out chains
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:StatusLow" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${MODULE_ID}:StatusLow" ) {
   field( DESC, "Lower 16 bit of module status register" )
   field( DTYP, "isegHAL" )
   field( DISV, "0" )  ## Disable Value (if value linked by SDIS == DISV record is disabled)
-  field( SDIS, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:PowerOn.VAL NPP MS" )
+  field( SDIS, "${P}${R}${CAN_LINE}:${DEVICE_ID}:PowerOn.VAL NPP MS" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.Status $(port)" )
   field( NOBT, "16" )
   field( SHFT, "0" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:StatusHigh" ) ## Build read out chains
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:StatusHigh" ) ## Build read out chains
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:StatusHigh" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${MODULE_ID}:StatusHigh" ) {
   field( DESC, "Higher 16 bit of module status register" )
   field( DTYP, "isegHAL" )
   field( DISV, "0" )  ## Disable Value (if value linked by SDIS == DISV record is disabled)
-  field( SDIS, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${DEVICE_ID}:PowerOn.VAL NPP MS" )
+  field( SDIS, "${P}${R}${CAN_LINE}:${DEVICE_ID}:PowerOn.VAL NPP MS" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.Status $(port)" )
   field( NOBT, "16" )
   field( SHFT, "16" )  ## shift the value by 16 bits to the right
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus" ) ## Build read out chains
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus" ) ## Build read out chains
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.EventStatus $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventMask" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventMask" )
   field( TSE,  "-2" )
 }
-record( longout, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventMask" ) {
+record( longout, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventMask" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.EventMask $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Temperature" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:Temperature" )
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:doClear" ) {
+record( bo, "${P}${R}${CAN_LINE}:${MODULE_ID}:Control:doClear" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.Control:6 $(port)" )
   field( ZNAM, "" )
@@ -280,7 +279,7 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:doClear" ) {
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:setFineAdjustment" ) {
+record( bo, "${P}${R}${CAN_LINE}:${MODULE_ID}:Control:setFineAdjustment" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.Control:12 $(port)" )
   field( ZNAM, "FineAdjustment off" )
@@ -288,7 +287,7 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:setFineAdjus
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:setKillEnable" ) {
+record( bo, "${P}${R}${CAN_LINE}:${MODULE_ID}:Control:setKillEnable" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.Control:14 $(port)" )
   field( ZNAM, "KillEnable off" )
@@ -296,7 +295,7 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:setKillEnabl
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:disableVoltageRampSpeedLimit" ) {
+record( bo, "${P}${R}${CAN_LINE}:${MODULE_ID}:Control:disableVoltageRampSpeedLimit" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.Control:16 $(port)" )
   field( ZNAM, "VoltageRampLimit enable" )
@@ -304,79 +303,79 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Control:disableVolta
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:VoltageRampSpeed" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:VoltageRampSpeed" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.VoltageRampSpeed $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:CurrentRampSpeed" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:CurrentRampSpeed" )
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:CurrentRampSpeed" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:CurrentRampSpeed" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.CurrentRampSpeed $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:VoltageLimit" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:VoltageLimit" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.VoltageLimit $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:CurrentLimit" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:CurrentLimit" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:CurrentLimit" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:CurrentLimit" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.CurrentLimit $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Temperature" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:Temperature" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.Temperature $(port)" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:SerialNumber" ) {
+record( longin, "${P}${R}${CAN_LINE}:${MODULE_ID}:SerialNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.SerialNumber $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:ChannelNumber" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:ChannelNumber" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:ChannelNumber" ) {
+record( longin, "${P}${R}${CAN_LINE}:${MODULE_ID}:ChannelNumber" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.ChannelNumber $(port)" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:SampleRate" ) {
+record( longin, "${P}${R}${CAN_LINE}:${MODULE_ID}:SampleRate" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.SampleRate $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:DigitalFilter" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:DigitalFilter" )
   field( TSE,  "-2" )
 }
 
-record( longin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:DigitalFilter" ) {
+record( longin, "${P}${R}${CAN_LINE}:${MODULE_ID}:DigitalFilter" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.DigitalFilter $(port)" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:FirmwareRelease" ) {
+record( stringin, "${P}${R}${CAN_LINE}:${MODULE_ID}:FirmwareRelease" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.FirmwareRelease $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:FirmwareName" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:FirmwareName" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:FirmwareName" ) {
+record( stringin, "${P}${R}${CAN_LINE}:${MODULE_ID}:FirmwareName" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.FirmwareName $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Article" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:Article" )
   field( TSE,  "-2" )
 }
 
-record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Article" ) {
+record( stringin, "${P}${R}${CAN_LINE}:${MODULE_ID}:Article" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.Article $(port)" )
   field( TSE,  "-2" )
@@ -386,7 +385,7 @@ record( stringin, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Article" ) {
 # ### Decoding of Module Status ### #
 #####################################
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isAdjustment" ) {
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isAdjustment" ) {
   field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.B0 CP" )
   field( ZNAM, "off" )
   field( ONAM, "on" )
@@ -394,88 +393,88 @@ record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isAdjustment" ) {
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status:isLiveInsertion" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.B2 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:Status:isLiveInsertion" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.B2 $(port)" )
   field( ZNAM, "off" )
   field( ONAM, "on" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:needService" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.B4 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:needService" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.B4 $(port)" )
   field( ZNAM, "ok" )
   field( ONAM, "Hardware failure detected" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isInputError" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.B6 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isInputError" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.B6 CP $(port)" )
   field( ZNAM, "ok" )
   field( ONAM, "Error" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MINOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isNoSumError" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.B8 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isNoSumError" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.B8 CP $(port)" )
   field( ZNAM, "Error" )
   field( ONAM, "ok" )
   field( ZSV,  "MAJOR" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isNoRamp" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.B9 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isNoRamp" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.B9 CP $(port)" )
   field( ZNAM, "channel is ramping" )
   field( ONAM, "all channels stable" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isSafetyLoopGood" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.BA CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isSafetyLoopGood" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.BA CP $(port)" )
   field( ZNAM, "broken" )
   field( ONAM, "closed" )
   field( ZSV,  "MAJOR" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isEVentActive" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.BB CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isEVentActive" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.BB CP $(port)" )
   field( ZNAM, "no active Event" )
   field( ONAM, "any event active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isModuleGood" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.BC CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isModuleGood" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.BC CP $(port)" )
   field( ZNAM, "failure" )
   field( ONAM, "ok" )
   field( ZSV,  "MAJOR" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isSuppliesGodd" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.BD CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isSuppliesGodd" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.BD CP $(port)" )
   field( ZNAM, "Out of Range" )
   field( ONAM, "ok" )
   field( ZSV,  "MAJOR" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isTemperatureGood" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.BE CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isTemperatureGood" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.BE CP $(port)" )
   field( ZNAM, "above 55 degC" )
   field( ONAM, "within range" )
   field( ZSV,  "MAJOR" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isKillEnable" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:Status.BF" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:isKillEnable" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:Status.BF $(port)" )
   field( ZNAM, "disabled" )
   field( ONAM, "enabled" )
   field( ZSV,  "NO_ALARM" )
@@ -485,48 +484,48 @@ record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:isKillEnable" ) {
 ###########################################
 # ### Decoding of Module Event Status ### #
 ###########################################
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventLiveInsertion" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus.B2 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventLiveInsertion" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus.B2 CP $(port)" )
   field( ZNAM, "off" )
   field( ONAM, "on" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventService" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus.B4 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventService" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus.B4 CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "Hardware failure detected" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventInputError" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus.B6 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventInputError" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus.B6 CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "Input Error in connection" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventSafetyLoopNotGood" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus.BA CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventSafetyLoopNotGood" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus.BA CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "Safety loop open" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventSuppliesNotGood" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus.BD CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventSuppliesNotGood" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus.BD CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "Supply is not good" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventTemperatureNotGood" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventStatus.BD CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:EventTemperatureNotGood" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:EventStatus.BD CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "Temperature above 55 degC" )
   field( ZSV,  "NO_ALARM" )
@@ -537,77 +536,77 @@ record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:EventTemperatureNotG
 # ### Channel item values ### #
 ###############################
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageSet" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageSet" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.VoltageSet $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentSet" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentSet" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.CurrentSet $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageMeasure" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageMeasure" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.VoltageMeasure $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentMeasure" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentMeasure" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentMeasure" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentMeasure" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.CurrentMeasure $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status" )
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageBounds" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageBounds" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.VoltageBounds $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentBounds" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentBounds" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.CurrentBounds $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageNominal" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VoltageNominal" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.VoltageNominal $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentNominal" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentNominal" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentNominal" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:CurrentNominal" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.CurrentNominal $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ai, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:TemperatureExternal" ) {
+record( ai, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:TemperatureExternal" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.TemperatureExternal $(port)" )
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VctCoefficient" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:VctCoefficient" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.VctCoefficient $(port)" )
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.Status $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus" )
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Control:setOn" ) {
+record( bo, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Control:setOn" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.Control:3 $(port)" )
   field( ZNAM, "Channel off" )
@@ -615,7 +614,7 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Contro
   field( TSE,  "-2" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Control:setEmergency" ) {
+record( bo, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Control:setEmergency" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.Control:5 $(port)" )
   field( ZNAM, "" )
@@ -623,32 +622,32 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Contro
   field( TSE,  "-2" )
 }
 
-record( mbbiDirect, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus" ) {
+record( mbbiDirect, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus" ) {
   field( DTYP, "isegHAL" )
   field( INP,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.EventStatus $(port)" )
   field( TSE,  "-2" )
 }
 
-record( longout, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventMask" ) {
+record( longout, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventMask" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.EventMask $(port)" )
   field( TSE,  "-2" )
 }
 
-record( longout, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:DelayedTripAction" ) {
+record( longout, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:DelayedTripAction" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.DelayedTripAction $(port)" )
-  field( FLNK, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:DelayedTripTime" )
+  field( FLNK, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:DelayedTripTime" )
   field( TSE,  "-2" )
 }
 
-record( ao, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:DelayedTripTime" ) {
+record( ao, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:DelayedTripTime" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.DelayedTripTime $(port)" )
   field( TSE,  "-2" )
 }
 
-record( longout, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ExternalInhibitAction" ) {
+record( longout, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ExternalInhibitAction" ) {
   field( DTYP, "isegHAL" )
   field( OUT,  "@${CAN_LINE}.${MODULE_ID}.${CHANNEL_ID}.ExternalInhibitAction $(port)" )
   field( TSE,  "-2" )
@@ -657,96 +656,96 @@ record( longout, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:E
 ######################################
 # ### Decoding of Channel Status ### #
 ######################################
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:InputError" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B2 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:InputError" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B2 CP $(port)" )
   field( ZNAM, "OK" )
   field( ONAM, "Input Error" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MINOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isOn" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B3 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isOn" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B3 CP $(port)" )
   field( ZNAM, "off" )
   field( ONAM, "on" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVoltageRamp" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B4 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVoltageRamp" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B4 CP $(port)" )
   field( ZNAM, "stable" )
   field( ONAM, "ramping" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isEmergency" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B5 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isEmergency" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B5 CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCC" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B6 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCC" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B6 CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCV" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B7 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCV" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.B7 CP $(port)" )
   field( ZNAM, "-" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCurrentBound" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BA CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCurrentBound" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BA CP $(port)" )
   field( ZNAM, "OK" )
   field( ONAM, "Out of bounds" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVoltageBound" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BB CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVoltageBound" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BB CP $(port)" )
   field( ZNAM, "OK" )
   field( ONAM, "Out of bounds" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isEventInhibit" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BC CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isEventInhibit" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BC CP $(port)" )
   field( ZNAM, "no" )
   field( ONAM, "yes" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isTrip" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BD CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isTrip" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BD CP $(port)" )
   field( ZNAM, "OK" )
   field( ONAM, "tripped" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCurrentLimit" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BE CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isCurrentLimit" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BE CP $(port)" )
   field( ZNAM, "OK" )
   field( ONAM, "exceeded" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVoltageLimit" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BF CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVoltageLimit" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:Status.BF CP $(port)" )
   field( ZNAM, "OK" )
   field( ONAM, "exceeded" )
   field( ZSV,  "NO_ALARM" )
@@ -756,96 +755,96 @@ record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:isVolt
 ############################################
 # ### Decoding of Channel Event Status ### #
 ############################################
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventInputError" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B2 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventInputError" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B2 CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MINOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EOn2Off" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B3 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EOn2Off" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B3 CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventEndOfRamp" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B4 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventEndOfRamp" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B4 CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventEmergency" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B5 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventEmergency" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B5 CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ECC" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B6 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ECC" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B6 CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ECV" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B7 CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ECV" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.B7 CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "NO_ALARM" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ECurrentBounds" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BA CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:ECurrentBounds" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BA CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EVVoltageBounds" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BB CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EVVoltageBounds" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BB CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventExternalInhibit" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BC CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventExternalInhibit" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BC CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventTrip" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BD CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventTrip" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BD CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventCurrentLimit" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BE CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventCurrentLimit" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BE CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
   field( OSV,  "MAJOR" )
 }
 
-record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventVoltageLimit" ) {
-  field( INP,  "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BF CP" )
+record( bi, "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventVoltageLimit" ) {
+  field( INP,  "${P}${R}${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventStatus.BF CP $(port)" )
   field( ZNAM, "--" )
   field( ONAM, "active" )
   field( ZSV,  "NO_ALARM" )
@@ -855,7 +854,7 @@ record( bi, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:${MODULE_ID}:${CHANNEL_ID}:EventV
 ###############################################################################################################
 # Global Switch
 #########################################################################################
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:GlobalOnOff" ) {
+record( bo, "${P}${R}${CAN_LINE}:GlobalOnOff" ) {
   field( DTYP, "isegHALglobal" )
   field( OUT,  "@OnOff $(port)" )
   field( TSE,  "-2" )
@@ -863,7 +862,7 @@ record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:GlobalOnOff" ) {
   field( ONAM, "On" )
 }
 
-record( bo, "ISEG:${CONTROLLER_SN}:${CAN_LINE}:GlobalEmergency" ) {
+record( bo, "${P}${R}${CAN_LINE}:GlobalEmergency" ) {
   field( DTYP, "isegHALglobal" )
   field( OUT,  "@Emergency $(port)" )
   field( TSE,  "-2" )


### PR DESCRIPTION
Allows sites to follow their own naming conventions.
Original ISEG:$CONTROLLER_SN can still be chosen in substitutions file if desired.