### PR TITLE
Output records don't need to be polled

### DIFF
--- a/devIsegHalApp/src/devIsegHalAo.c
+++ b/devIsegHalApp/src/devIsegHalAo.c
@@ -82,7 +82,7 @@ epicsExportAddress( dset, devIsegHalAo );
 static long devIsegHalInitRecord_ao( aoRecord *prec ){
   prec->pact = (epicsUInt8)true; /* disable record */
 
-  devIsegHal_rec_t conf = { &prec->out, "WR", "R4", true };
+  devIsegHal_rec_t conf = { &prec->out, "WR", "R4", false };
   long status = devIsegHalInitRecord( (dbCommon*)prec, &conf );
   if( status != 0 ) return ERROR;
 

--- a/devIsegHalApp/src/devIsegHalBo.c
+++ b/devIsegHalApp/src/devIsegHalBo.c
@@ -81,7 +81,7 @@ epicsExportAddress( dset, devIsegHalBo );
 static long devIsegHalInitRecord_bo( boRecord *prec ){
   prec->pact = (epicsUInt8)true; /* disable record */
 
-  devIsegHal_rec_t conf = { &prec->out, "WR", "BOOL", true };
+  devIsegHal_rec_t conf = { &prec->out, "WR", "BOOL", false };
   long status = devIsegHalInitRecord( (dbCommon*)prec, &conf );
   if( status != 0 ) return ERROR;
 

--- a/devIsegHalApp/src/devIsegHalLo.c
+++ b/devIsegHalApp/src/devIsegHalLo.c
@@ -81,7 +81,7 @@ epicsExportAddress( dset, devIsegHalLo );
 static long devIsegHalInitRecord_lo( longoutRecord *prec ){
   prec->pact = (epicsUInt8)true; /* disable record */
 
-  devIsegHal_rec_t conf = { &prec->out, "WR", "UI", true };
+  devIsegHal_rec_t conf = { &prec->out, "WR", "UI", false };
   long status = devIsegHalInitRecord( (dbCommon*)prec, &conf );
   if( status != 0 ) return ERROR;
 


### PR DESCRIPTION
No need to poll output records.
About the only reason I can see for polling output records would be to pick up any
changes made via web UI, however, this can introduce race conditions where
an earlier web UI change to a value could be picked up by the output record which
then overwrites a subsequent web UI change if they are close enough together.